### PR TITLE
fixed typos and formatting in the docs

### DIFF
--- a/docs/data_type_handler.md
+++ b/docs/data_type_handler.md
@@ -1,13 +1,10 @@
-# Data Type Handler microservice
-This Microservice changes data type from stored file between number and string.
+# Data Type Handler Microservice
+This microservice changes data type from stored file between number and string.
 
 ## Change fields type of inserted file
 `PATCH CLUSTER_IP:5003/fieldtypes/<filename>`
 
-The request uses filename as id in argument and fields in body, fields are an 
-array with all fields from file to be changed, using number or string 
-descriptor in each Key:Value to describe the new value of altered field of 
-file.
+The request uses `filename` as the id in the parameters and fields in the body, `fields` is an array with all fields from file to be changed, using `number` or string descriptor in each `Key:Value` to describe the new value of altered field of file.
 
 ```json
 {

--- a/docs/database_api.md
+++ b/docs/database_api.md
@@ -1,25 +1,18 @@
 # Database API microservice
 
-The Database API microservice creates a level of abstraction through an REST 
-API to use the MongoDB, dataset are downloaded in csv and handled in json 
-format, the primary key for each document is the filename field contained in 
-the sent json file from POST request.
+The Database API microservice creates a level of abstraction through a REST API. Using MongoDB, datasets are downloaded in CSV format and parsed into JSON format where the primary key for each document is the filename field contained in the JSON file POST request.
 
 ## GUI tool to handle database files
-There are GUI tools to handle database files, as example, the 
-[NoSQLBooster](https://nosqlbooster.com) can interact with mongoDB used in 
-database, and makes several tasks which are limited in 
-learning\_orchestra\_client package, as schema visualization and files 
-extraction and download to formats as csv, json, you also can navigate in all 
-inserted files in easy way and visualize each row from determined file, to use 
-this tool, connect with the url cluster\_ip:27017 and use the user root with 
-password owl45#21.
+There are GUI tools to handle database files, for example, [NoSQLBooster](https://nosqlbooster.com) can interact with mongoDB used in database, and makes several tasks which are limited in `learning\_orchestra\_client package`, as schema visualization and files extraction and download to formats as CSV, JSON, you also can navigate in all inserted files in easy way and visualize each row from determined file, to use this tool connect with the url `cluster\_ip:27017` and use the credentials
+```
+username = root
+password = owl45#21
+```
 
 ## List all inserted files
 `GET CLUSTER_IP:5000/files`
 
-Return an array of metadata files in database, each file inserted in database 
-contains a metadata file.
+Returns an array of metadata files from the database, where each file contains a metadata file.
 
 ### Downloaded files metadata 
 ```json
@@ -45,12 +38,11 @@ contains a metadata file.
 }
 ```
 
-* fields - column names from inserted file
-* filename - name to file identification
-* finished - flag used to indicate if asynchronous processing from file 
-downloader is finished
-* time_created - creation time of file
-* url - url used to file download
+* `fields` - Names of the columns in the file
+* `filename` - Name of the file
+* `finished` - Flag used to indicate if asynchronous processing from file downloader is finished
+* `time_created` - Time of creation
+* `url` - URL used to download the file
 
 ### Preprocessed files metadata
 ```json
@@ -73,10 +65,9 @@ downloader is finished
 }
 ```
 
-* parent_filename - file filename used to make a preprocess task, deriving
-this filename.
+* `parent_filename` - The `filename` used to make a preprocess task, from which the current file is derived.
 
-### Classificator prediction files metadata
+### Classifier prediction files metadata
 
 ```json
 {
@@ -88,33 +79,31 @@ this filename.
 }
 ```
 
-* F1 - F1 Score from model accuracy
-* accuracy - accuracy rate from model prediction
-* classificator - initials from used classificator
-* error - error rate from model prediction
-* fit_time - time from model fit using training dataset
+* `F1` - F1 Score from model accuracy
+* `accuracy` - Accuracy rate from model prediction
+* `classificator` - Initials from used classificator
+* `error` - Error rate from the model prediction
+* `fit_time` - Time taken for the model to be fit during training
 
 ## List file content
 
 `GET CLUSTER_IP:5000/files/<filename>?skip=number&limit=number&query={}`
 
-Return rows of filename, and paginate in query result.
+Returns rows of the file requested, with pagination
 
-* filename - filename of inserted file
-* skip - amount lines to skip in csv file
-* limit - limit of returned query result, max limit setted in 20 rows
-* query - query to find documents, if use method only to paginate, use blank 
-json, as {}
+* `filename` - Name of file requests
+* `skip` - Amount of lines to skip in the CSV file
+* `limit` - Limit the query result, maximum limit set to 20 rows
+* `query` - Query to find documents, if only pagination is requested, `query` should be empty curly brackets `query={}`
 
-The first row is always the metadata file.
+The first row in the query is always the metadata file.
 
-## Insert file from URL
+## Post file
 
 `POST CLUSTER_IP:5000/files`
 
-Insert a csv into the database using the POST method, json must be contained 
-in the body of the http request.
-The inserted json musts has the fields: 
+Insert a CSV into the database using the POST method, JSON must be contained in the body of the HTTP request.
+The following fields are required: 
 ```json
 {
     "filename": "key_to_document_identification",
@@ -122,10 +111,8 @@ The inserted json musts has the fields:
 }
 ```
 
-## Delete inserted file
+## Delete an existing file
 `DELETE CLUSTER_IP:5000/files/<filename>`
 
-Request of type DELETE, informing the value of filename field of a inserted 
-file in argument request, deleting the database file, if one exist with that 
-value.
+Request of type `DELETE`, passing the `filename` field of an existing file in the request parameters, deleting the file in the database.
 

--- a/docs/database_api.md
+++ b/docs/database_api.md
@@ -82,7 +82,7 @@ Returns an array of metadata files from the database, where each file contains a
 * `F1` - F1 Score from model accuracy
 * `accuracy` - Accuracy rate from model prediction
 * `classificator` - Initials from used classificator
-* `error` - Error rate from the model prediction
+* `filename` - Name of the file 
 * `fit_time` - Time taken for the model to be fit during training
 
 ## List file content

--- a/docs/histogram.md
+++ b/docs/histogram.md
@@ -1,13 +1,10 @@
 # Histogram microservice
-Microservice used to makes the histogram from a stored file, storing the result 
-in a new file in MongoDB.
+Microservice used to make the histogram from a stored file, storing the resulting histogram in a new file in MongoDB.
 
-## Create a Histogram from inserted file
+## Create a Histogram from posted file
 `POST CLUSTER_IP:5004/histograms/<filename>`
 
-The request is sent in body, histrogram_filename is the filename to save the 
-histogram result and fields are an array with all fields to make the 
-histogram.
+The request is sent in the body, `histogram_filename` is the name of the file in which the histogram result is saved to and `fields` is an array with all the fields necessary to make the histogram.
 
 ```json
 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ A dataset (in CSV format) can be loaded from an URL using the[Database API](http
 
 It is also possible to perform several preprocessing and analytical tasks using learningOrchestra's [collection of microservices](https://riibeirogabriel.github.io/learningOrchestra/usage).
 
-With learningOrchestra, you can build prediction models with different classifiers simultaneously using stored and preprocessed datasets with the *Model Builder* microservice. This microservice uses a [Spark](https://spark.apache.org/) cluster to make rediction models using distributed processing. You can compare the different classification results over time to fit and increase prediction accuracy.
+With learningOrchestra, you can build prediction models with different classifiers simultaneously using stored and preprocessed datasets with the *Model Builder* microservice. This microservice uses a [Spark](https://spark.apache.org/) cluster to make prediction models using distributed processing. You can compare the different classification results over time to fit and increase prediction accuracy.
 
 By providing their own preprocessing code, users can create highly customized model predictions against a specific dataset, increasing model prediction accuracy. With that in mind, the possibilities are endless! 🚀
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,54 +6,38 @@
 
 ## Objective
 
-The goal of this work is to develop a tool, named *learningOrchestra*, to
-facilitate and streamline the data science iterative process of:
+The goal of this work is to develop a tool, named *learningOrchestra*, to facilitate and streamline the data science iterative process of:
 
-* Gathering data;
-* Cleaning/preparing the datasets;
-* Building models;
-* Validating their predictions; and
-* Deploying the results.
+* Gathering data
+* Cleaning/preparing the datasets
+* Building models
+* Validating their predictions, and
+* Deploying the results
 
 ## Architecture
 
-The architecture of learningOrchestra is a collection of microservices deployed
-in a cluster.
+The architecture of learningOrchestra is a collection of microservices deployed in a cluster.
 
 ![architecture](./architecture.png)
 
-A dataset (in CSV format) can be loaded from an URL using the
-[Database API](https://riibeirogabriel.github.io/learningOrchestra/database_api) 
-microservice, which converts the dataset to JSON and later stores it in MongoDB.
+A dataset (in CSV format) can be loaded from an URL using the[Database API](https://riibeirogabriel.github.io/learningOrchestra/database_api) microservice, which converts the dataset to JSON and later stores it in MongoDB.
 
-It is also possible to perform several preprocessing and analytical tasks using 
-learningOrchestra's [collection of microservices](https://riibeirogabriel.github.io/learningOrchestra/usage).
+It is also possible to perform several preprocessing and analytical tasks using learningOrchestra's [collection of microservices](https://riibeirogabriel.github.io/learningOrchestra/usage).
 
-With learningOrchestra, you can build prediction models with different 
-classificators simultaneously using stored and preprocessed datasets with the
-*Model Builder* microservice. This microservice uses a [Spark](https://spark.apache.org/)
-cluster to make prediction models using distributed processing. You can compare the different 
-classification results over time to fit and increase prediction accuracy.
+With learningOrchestra, you can build prediction models with different classifiers simultaneously using stored and preprocessed datasets with the *Model Builder* microservice. This microservice uses a [Spark](https://spark.apache.org/) cluster to make rediction models using distributed processing. You can compare the different classification results over time to fit and increase prediction accuracy.
 
-By providing their own preprocessing code, users can create highly customized model predictions
-against a specific dataset, increasing model prediction accuracy.
-With that in mind, the possibilities are endless! 🚀
+By providing their own preprocessing code, users can create highly customized model predictions against a specific dataset, increasing model prediction accuracy. With that in mind, the possibilities are endless! 🚀
 
 
 ## Getting Started
 
-To make using learningOrchestra more accessible, we provide the 
-`learning_orchestra_client` Python package. This package provides developers with all of 
-learningOrchestra's functionalities in a Python API.
+To make using learningOrchestra more accessible, we provide the `learning_orchestra_client` Python package. This package provides developers with all of learningOrchestra's functionalities in a Python API.
 
-To improve your user experience, you can export and analyse the results using a MongoDB GUI, such as 
-[NoSQLBooster](https://nosqlbooster.com).
+To improve user experience, a user can export and analyse the results using a MongoDB GUI framework, such as [NoSQLBooster](https://nosqlbooster.com).
 
-We also built a
-[demo of learningOrchestra](https://pypi.org/project/learning-orchestra-client/) (in *learning_orchestra_client usage example* section)
-with the [Titanic challenge dataset](https://www.kaggle.com/c/titanic).
+We also built a [demo of learningOrchestra](https://pypi.org/project/learning-orchestra-client/) (in *learning_orchestra_client usage example* section) with the [Titanic challenge dataset](https://www.kaggle.com/c/titanic).
 
-This documentation has more details on how to install and use it. We also provided documentation and examples for each microservice and Python package.
+This documentation has a more detailed description on how to install and use it. We also provide documentation and examples for each microservice and the Python package.
 
 
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,35 +3,24 @@
 ## Requirements
 
 * Linux hosts;
-* [Docker Engine](https://docs.docker.com/engine/install/) installed in all 
-instances of your cluster;
-* cluster configured in swarm mode, more details in 
-[swarm documentation](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/);
-* [Docker Compose](https://docs.docker.com/compose/install/) installed in 
-manager instance of your cluster; and
-* Ensure which your cluster environment has no network traffic block, as 
-firewalls rules in your network or owner firewall in linux hosts, case has 
-firewalls or other blockers, insert learningOrchestra in blocked exceptions, as
- example, in Google Cloud Platform the VMs must be with allow_http and 
- allow_https firewall rules allowed in each VM configuration.
+* [Docker Engine](https://docs.docker.com/engine/install/) installed in all instances of your cluster;
+* Cluster configured in swarm mode, more details in [swarm documentation](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/);
+* [Docker Compose](https://docs.docker.com/compose/install/) installed in manager instance of your cluster; and
+* Ensure which your cluster environment has no network traffic block, as firewalls rules in your network or owner firewall in linux hosts, case has firewalls or other blockers, insert learningOrchestra in blocked exceptions, as example, in Google Cloud Platform the VMs must be with allow_http and allow_https firewall rules allowed in each VM configuration.
 
 ## Deploy
 
-Ensure which your location path is in project root (./learningOrchestra), in 
-sequence, run the command bellow in manager instance of your swarm cluster to 
-deploy the learningOrchestra:
+Ensure that you are located in the project root `./learningOrchestra` and run the command below in `sudo` mode in your swarm cluster to deploy the learningOrchestra:
 ```
 sudo ./run.sh
 ```
-If all things happen good, the learningOrchestra has been deployed in your 
-swarm cluster, congrulations! 🥳 👏
+If everything goes according to plan, learningOrchestra has been deployed in your swarm cluster. Congrulations! 🥳 👏
 
-## learningOrchestra cluster state
+## learningOrchestra Cluster State
 There are two web pages for cluster state visualization:
 
-* Visualize cluster state (deployed microservices and cluster's machines) - 
-CLUSTER_IP:80; and
-* Visualize spark cluster state - CLUSTER_IP:8080.
+* Visualize cluster state (deployed microservices and cluster's machines) - `CLUSTER_IP:80`
+* Visualize spark cluster state - `CLUSTER_IP:8080`.
 
-The CLUSTER_IP is an external ip of some machine of your cluster.
+The `CLUSTER_IP` is an external IP of a machine in your cluster.
 

--- a/docs/learning_orchestra_client_package.md
+++ b/docs/learning_orchestra_client_package.md
@@ -1,4 +1,3 @@
-# learningOrchestra client package
+# learningOrchestra Client Package
 
-You can know how install and use this package at 
-[learning_orchestra_client repositoy](https://pypi.org/project/learning-orchestra-client/).
+You can know how install and use this package at [learning_orchestra_client](https://pypi.org/project/learning-orchestra-client/) repository.

--- a/docs/model_builder.md
+++ b/docs/model_builder.md
@@ -1,7 +1,5 @@
-# Model builder microservice
-Model Builder microservice provides a REST API to create several model 
-predictions using your own preprocessing code using a defined set of 
-classificators. 
+# Model Builder Microservice
+Model Builder microservice provides a REST API to create several model predictions using your own preprocessing code using a defined set of classifiers. 
 
 ## Create prediction model
 `POST CLUSTER_IP:5002/models`
@@ -14,15 +12,15 @@ classificators.
     "classificators_list": "String list of classificators to be used"
 }
 ```
-### classificators_list
+### List of Classifiers
 
-* "lr": LogisticRegression
-* "dt": DecisionTreeClassifier
-* "rf": RandomForestClassifier
-* "gb": Gradient-boosted tree classifier
-* "nb": NaiveBayes
+* `lr`: LogisticRegression
+* `dt`: DecisionTreeClassifier
+* `rf`: RandomForestClassifier
+* `gb`: Gradient-boosted tree classifier
+* `nb`: NaiveBayes
 
-to send a request with LogisticRegression and NaiveBayes classificators:
+To send a request with LogisticRegression and NaiveBayes Classifiers:
 ```json
 {
     "training_filename": "training filename",
@@ -36,36 +34,29 @@ to send a request with LogisticRegression and NaiveBayes classificators:
 
 The python 3 preprocessing code must use the environment instances in bellow:
 
-* training_df (Instantiated): Spark Dataframe instance for training filename
-* testing_df  (Instantiated): Spark Dataframe instance for testing filename
+* `training_df` (Instantiated): Spark Dataframe instance training filename
+* `testing_df`  (Instantiated): Spark Dataframe instance testing filename
 
-The preprocessing code must instantiates the variables in bellow, all 
-instances must be transformed by pyspark VectorAssembler:
+The preprocessing code must instantiate the variables in below, all instances must be transformed by pyspark VectorAssembler:
 
-* features_training (Not Instantiated): Spark Dataframe instance for train 
-the model
-* features_evaluation (Not Instantiated): Spark Dataframe instance for 
-evaluate trained model accuracy
-* features_testing (Not Instantiated): Spark Dataframe instance for test 
-the model
+* `features_training` (Not Instantiated): Spark Dataframe instance for train the model
+* `features_evaluation` (Not Instantiated): Spark Dataframe instance for evaluating trained model accuracy
+* `features_testing` (Not Instantiated): Spark Dataframe instance for testing the model
 
-Case you don't want evaluate the model prediction, define features_evaluation 
-as None.
+In case you don't want to evaluate the model, set `features_evaluation` as `None`.
 
 #### Handy methods
 
 ```python
 self.fields_from_dataframe(self, dataframe, is_string)
 ```
-This method returns string or number fields as string list from a dataframe.
+This method returns string or number fields as a string list from a DataFrame.
 
-* dataframe: dataframe instance
-* is_string: Boolean parameter, if True, the method returns the string 
-dataframe fields, otherwise, returns the numbers dataframe fields.
+* `dataframe`: DataFrame instance
+* `is_string`: Boolean parameter, if `True`, the method returns the string DataFrame fields, otherwise, returns the numbers DataFrame fields.
 
-#### preprocessor_code example
-This example uses the 
-[titanic challengue datasets](https://www.kaggle.com/c/titanic/overview).
+#### preprocessor_code Example
+This example uses the [titanic challengue datasets](https://www.kaggle.com/c/titanic/overview).
 
 ```python
 from pyspark.ml import Pipeline

--- a/docs/pca.md
+++ b/docs/pca.md
@@ -1,34 +1,20 @@
 # PCA microservice
-PCA is used to decompose a multivariate dataset in a set of successive 
-orthogonal components that explain a maximum amount of the variance. In 
-scikit-learn (used in this microservice), PCA is implemented as a transformer 
-object that learns components in its fit method, and can be used on new data 
-to project it on these components.
+PCA is used to decompose a multivariate dataset in a set of successive orthogonal components that explain a maximum amount of the variance. In `scikit-learn` (used in this microservice), PCA is implemented as a transformer object that learns components in its fit method, and can be used on new data to project it on these components.
 
-PCA centers but does not scale the input data for each feature before applying 
-the SVD. The optional parameter whiten=True makes it possible to project the 
-data onto the singular space while scaling each component to unit variance. 
-This is often useful if the models down-stream make strong assumptions on the 
-isotropy of the signal: this is for example the case for Support Vector 
-Machines with the RBF kernel and the K-Means clustering algorithm, more 
-information about this algorithm in 
-[scikit-learn PCA docs](https://scikit-learn.org/stable/modules/decomposition.html#pca).
+PCA centers but does not scale the input data for each feature before applying the SVD. The optional parameter `whiten = True` makes it possible to project the data onto the singular space while scaling each component to unit variance. This is often useful if the models down-stream make strong assumptions on the isotropy of the signal: this is for example the case for Support Vector Machines with the RBF kernel and the K-Means clustering algorithm, more information about this algorithm in [scikit-learn PCA docs](https://scikit-learn.org/stable/modules/decomposition.html#pca).
 
 ## Create an image plot
 
 `POST CLUSTER_IP:5006/images/<parent_filename>`
 
-The request uses a parent_filename as a dataset inserted filename, the body 
-contains the json fields:
+The request uses a `parent_filename` as a dataset filename, the body contains the json fields:
 ```json
 {
     "pca_filename": "image_plot_filename",
     "label_name": "dataset_label_column"
 }
 ```
-The "label_name" is the label name column for machine learning datasets which 
-has labeled tuples, case of the dataset used doesn't contain labeled tuples, 
-define the value as null type in json:
+The `label_name` is the label name column for machine learning datasets which has labeled tuples. In the case that the dataset used doesn't contain labeled tuples, define the value as null type in JSON:
 ```json
 {
     "pca_filename": "image_plot_filename",
@@ -39,21 +25,22 @@ define the value as null type in json:
 
 `DELETE CLUSTER_IP:5006/images/<image_plot_filename>`
 
+Deletes an image plot from the database.
+
 ## Read the filenames of the created images
 
 `GET CLUSTER_IP:5006/images`
 
-This request return a list with all created images plot filenames.
+Returns a list with all created image plot filenames.
  
 ## Read an image plot
 
 `GET CLUSTER_IP:5006/images/<image_plot_filename>`
 
-This request return return the image plot of filename.
+Returns the image plot of `filename` specified.
 
 ### Images plot examples
-This examples use the 
-[titanic challengue datasets](https://www.kaggle.com/c/titanic/overview).
+This examples use the [titanic challengue datasets](https://www.kaggle.com/c/titanic/overview).
 #### Titanic Train dataset
 ![](./pca_titanic_train.png)
 

--- a/docs/projection.md
+++ b/docs/projection.md
@@ -1,10 +1,9 @@
-# Projection microservice
-Projection microservice provides an api to make a projection from file inserted 
-in database service, generating a new file and putting in database.
+# Projection Microservice
+Projection microservice provides an api to make a projection from file inserted in database service, generating a new file and putting in database.
 
 ## Create projection from a inserted file
 `POST CLUSTER_IP:5001/projections/<filename>`
-
+Post request where `filename` is the name of the file to create a projection for.
 ```json
 {
     "projection_filename" : "filename_to_save_projection",

--- a/docs/t_sne.md
+++ b/docs/t_sne.md
@@ -1,30 +1,20 @@
-# t-SNE microservice
-The T-distributed Stochastic Neighbor Embedding (t-SNE) is a machine learning 
-algorithm for visualization. It is a nonlinear dimensionality reduction 
-technique well-suited for embedding high-dimensional data for visualization in 
-a low-dimensional space of two or three dimensions. 
+# t-SNE Microservice
+The T-distributed Stochastic Neighbor Embedding (t-SNE) is a machine learning algorithm for visualization. It is a nonlinear dimensionality reduction technique well-suited for embedding high-dimensional data for visualization in a low-dimensional space of two or three dimensions. 
 
-Specifically, it models each high-dimensional object by a two- or 
-three-dimensional point in such a way that similar objects are modeled by 
-nearby points and dissimilar objects are modeled by distant points with high 
-probability, more information about this algorithm in 
-[wikipedia]( https://en.wikipedia.org/wiki/T-distributed_stochastic_neighbor_embedding).
+Specifically, it models each high-dimensional object by a two- or three-dimensional point in such a way that similar objects are modeled by nearby points and dissimilar objects are modeled by distant points with high probability, more information about this algorithm in its [Wiki page]( https://en.wikipedia.org/wiki/T-distributed_stochastic_neighbor_embedding).
 
 ## Create an image plot
 
 `POST CLUSTER_IP:5005/images/<parent_filename>`
 
-The request uses a parent_filename as a dataset inserted filename, the body 
-contains the json fields:
+The request uses a `parent_filename` as a dataset inserted filename, the body contains the JSON fields:
 ```json
 {
     "tsne_filename": "image_plot_filename",
     "label_name": "dataset_label_column"
 }
 ```
-The "label_name" is the label name column for machine learning datasets which 
-has labeled tuples, case of the dataset used doesn't contain labeled tuples, 
-define the value as null type in json:
+The `label_name` is the label name of the column for machine learning datasets which has labeled tuples. In the case that the dataset used doesn't contain labeled tuples, define the value as null type in json:
 ```json
 {
     "tsne_filename": "image_plot_filename",
@@ -34,22 +24,22 @@ define the value as null type in json:
 ## Delete an image plot
 
 `DELETE CLUSTER_IP:5005/images/<image_plot_filename>`
+Deletes an image plot by specifying its file name.
 
 ## Read the filenames of the created images
 
 `GET CLUSTER_IP:5005/images`
 
-This request return a list with all created images plot filenames.
+Returns a list with all created images plot file name.
  
 ## Read an image plot
 
 `GET CLUSTER_IP:5005/images/<image_plot_filename>`
 
-This request return return the image plot of filename.
+Returns the image plot of the specified file name.
 
 ### Images plot examples
-This examples use the 
-[titanic challengue datasets](https://www.kaggle.com/c/titanic/overview).
+This examples use the [titanic challengue datasets](https://www.kaggle.com/c/titanic/overview).
 #### Titanic Train dataset
 ![](./tsne_titanic_train.png)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -3,38 +3,21 @@
 * [learningOrchestra Client](https://riibeirogabriel.github.io/learningOrchestra/learning_orchestra_client_package) - The python package for learningOrchestra use
 
 ## Microservices REST API
-* [database api](https://riibeirogabriel.github.io/learningOrchestra/database_api) - 
-Microservice used to download and handling files in database;
-* [projection](https://riibeirogabriel.github.io/learningOrchestra/projection) - 
-Makes projections of stored files in database using spark cluster;
-* [data type handler](https://riibeirogabriel.github.io/learningOrchestra/data_type_handler) - 
-Changes fields file type between number and text;
-* [histogram](https://riibeirogabriel.github.io/learningOrchestra/histogram) - 
-Makes histograms of stored files in database;
-* [t-SNE](https://riibeirogabriel.github.io/learningOrchestra/t_sne) - 
-Makes a t-SNE image plot of stored files in database;
-* [PCA](https://riibeirogabriel.github.io/learningOrchestra/pca) - 
-Makes a PCA image plot of stored files in database; and
-* [model builder](https://riibeirogabriel.github.io/learningOrchestra/model_builder) - 
-Creates a prediction model from preprocessed files using spark cluster.
+* [database api](https://riibeirogabriel.github.io/learningOrchestra/database_api) - Microservice used to download and handling files in database;
+* [projection](https://riibeirogabriel.github.io/learningOrchestra/projection) - Makes projections of stored files in database using spark cluster;
+* [data type handler](https://riibeirogabriel.github.io/learningOrchestra/data_type_handler) - Changes fields file type between number and text;
+* [histogram](https://riibeirogabriel.github.io/learningOrchestra/histogram) - Makes histograms of stored files in database;
+* [t-SNE](https://riibeirogabriel.github.io/learningOrchestra/t_sne) - Makes a t-SNE image plot of stored files in database;
+* [PCA](https://riibeirogabriel.github.io/learningOrchestra/pca) - Makes a PCA image plot of stored files in database; and
+* [model builder](https://riibeirogabriel.github.io/learningOrchestra/model_builder) - Creates a prediction model from preprocessed files using spark cluster.
 
 ## Spark microservice
-The projection, t-SNE, PCA and model builder microservices use the spark 
-microservice to make your works, by default, this microservice has one instance, 
-in case of you data processing require more computing processing, you can 
-scale this microservice to earn computing power, to this, with learningOrchestra 
-already deployed, in your master machine of you docker swarm cluster, run:
+The projection, t-SNE, PCA and model builder microservices use the spark microservice to make your work. By default, this microservice has only one instance. In case your data processing requires more computing processing power, you can scale this microservice to earn computing power. To do this, with learningOrchestra already deployed, in the master machine of your docker swarm cluster, run:
 
 ```
 docker service scale microservice_sparkworker=NUMBER_OF_INSTANCES
 ```
-The NUMBER_OF_INSTANCES is the amount of spark microservice instance which you 
-desire to be created in your cluster, this number must be choosed according 
-with your cluster resources and the resources requirements of your task.
+The `NUMBER_OF_INSTANCES` is the amount of spark microservice instances which you desire to be created in your cluster, this number must be choosen according to your cluster resources and the resource requirements of your task.
 
 ## Database GUI
-* [NoSQLBooster](https://nosqlbooster.com) - 
-MongoDB GUI makes several database tasks, as files visualization, queries, 
-projections and files extraction to formats as csv and json, read the 
-[database api docs](https://riibeirogabriel.github.io/learningOrchestra/database_api) 
-to learn how configure this tool.
+* [NoSQLBooster](https://nosqlbooster.com) - MongoDB GUI performs several database tasks, such as files visualization, queries, projections and files extraction to formats as CSV and JSON, read the database [api docs](https://riibeirogabriel.github.io/learningOrchestra/database_api) to learn how to configure this tool.

--- a/readme.md
+++ b/readme.md
@@ -6,9 +6,7 @@
 
 ## Objective
 
-The goal of this work is to develop a tool, named *learningOrchestra*, to
-facilitate and streamline the data science iterative process of:
-
+The goal of this work is to develop a tool, named *learningOrchestra*, to facilitate and streamline the data science iterative rocess of:
 * Gathering data;
 * Cleaning/preparing the datasets;
 * Building models;
@@ -22,37 +20,22 @@ facilitate and streamline the data science iterative process of:
   <img src="./docs/architecture.png" width="70%">
 </p>
                                                                        
-The architecture of learningOrchestra is a collection of microservices deployed
-in a cluster.
+The architecture of learningOrchestra is a collection of microservices deployed in a cluster.
 
-A dataset (in CSV format) can be loaded from an URL using the
-[Database API](https://riibeirogabriel.github.io/learningOrchestra/database_api) 
-microservice, which converts the dataset to JSON and later stores it in MongoDB.
+A dataset (in CSV format) can be loaded from an URL using the [Database API](https://riibeirogabriel.github.io/learningOrchestra/database_api) microservice, which converts the dataset to JSON and later stores it in MongoDB.
 
-It is also possible to perform several preprocessing and analytical tasks using 
-learningOrchestra's [collection of microservices](https://riibeirogabriel.github.io/learningOrchestra/usage).
+It is also possible to perform several preprocessing and analytical tasks using learningOrchestra's [collection of microservices](https://riibeirogabriel.github.io/learningOrchestra/usage).
 
-With learningOrchestra, you can build prediction models with different 
-classificators simultaneously using stored and preprocessed datasets with the
-*Model Builder* microservice. This microservice uses a [Spark](https://spark.apache.org/)
-cluster to make prediction models using distributed processing. You can compare the different 
-classification results over time to fit and increase prediction accuracy.
+With learningOrchestra, you can build prediction models with different classifiers simultaneously using stored and preprocessed datasets with the *Model Builder* microservice. This microservice uses a [Spark](https://spark.apache.org/) cluster to make prediction models using distributed processing. You can compare the different classification results over time to fit and increase prediction accuracy.
 
-By providing their own preprocessing code, users can create highly customized model predictions
-against a specific dataset, increasing model prediction accuracy.
-With that in mind, the possibilities are endless! 🚀
+By providing their own preprocessing code, users can create highly customized model predictions against a specific dataset, increasing model prediction accuracy. With that in mind, the possibilities are endless! 🚀
 
 ## Getting Started
 
-To make using learningOrchestra more accessible, we provide the 
-`learning_orchestra_client` Python package. This package provides developers with all of 
-learningOrchestra's functionalities in a Python API.
+To make using learningOrchestra more accessible, we provide the `learning_orchestra_client` Python package. This package provides developers with all of learningOrchestra's functionalities in a Python API.
 
-To improve your user experience, you can export and analyse the results using a MongoDB GUI, such as 
-[NoSQLBooster](https://nosqlbooster.com).
+To improve user experience, a user can export and analyse the results using a MongoDB GUI, such as [NoSQLBooster](https://nosqlbooster.com).
 
-We also built a
-[demo of learningOrchestra](https://pypi.org/project/learning-orchestra-client/) (in *learning_orchestra_client usage example* section)
-with the [Titanic challenge dataset](https://www.kaggle.com/c/titanic).
+We also built a [demo](https://pypi.org/project/learning-orchestra-client/) of learningOrchestra (in *learning_orchestra_client usage example* section) with the [Titanic challenge dataset](https://www.kaggle.com/c/titanic).
 
-The [learningOrchestra documentation](https://riibeirogabriel.github.io/learningOrchestra) has more details on how to install and use it. We also provided documentation and examples for each microservice and Python package.
+The learningOrchestra [documentation](https://riibeirogabriel.github.io/learningOrchestra) has a more detailed guide on how to install and use it. We also provide documentation and examples for each microservice and Python package.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 ## Objective
 
-The goal of this work is to develop a tool, named *learningOrchestra*, to facilitate and streamline the data science iterative rocess of:
+The goal of this work is to develop a tool, named *learningOrchestra*, to facilitate and streamline the data science iterative process of:
 * Gathering data;
 * Cleaning/preparing the datasets;
 * Building models;


### PR DESCRIPTION
This addresses issue #61.

Some formatting and rewording in the docs

I noticed that in [docs/database_api.md](docs/database_api.md) you have this:

### Classifier prediction files metadata

```json
{
    "F1": "0.7030995388400528",
    "accuracy": "0.7034883720930233",
    "classificator": "nb",
    "filename": "titanic_testing_new_prediction_nb",
    "fit_time": 41.870062828063965
}
```

* `F1` - F1 Score from model accuracy
* `accuracy` - Accuracy rate from model prediction
* `classificator` - Initials from used classificator
* `error` - Error rate from the model prediction
* `fit_time` - Time taken for the model to be fit during training

The fields breakdown has the `error` field that doens't exist in the JSON response.
I'm not sure what to do with that.